### PR TITLE
Add entrypoint script for Render deployment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH="${PYTHONPATH:-}:$(pwd)/src"
+
+exec python run_server.py


### PR DESCRIPTION
## Summary
- add an entrypoint script that sets PYTHONPATH and launches the server via run_server.py
- ensure the script can be executed by Render's start command

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df7ed5dfa4832ca001b57d78f9175a