### PR TITLE
Update Render health check to use MCP endpoint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: free
     buildCommand: "pip install -r requirements.txt"
     startCommand: "bash entrypoint.sh"
-    healthCheckPath: /
+    healthCheckPath: /mcp/
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.10


### PR DESCRIPTION
## Summary
- point the Render service health check to the /mcp/ endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa906bf4c832c837b3607f7011cc1